### PR TITLE
feat: 新增 tmux 相容終端切換快捷鍵

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ vim.g.mapleader = " "  -- 空格鍵作為領導鍵
 
 ### 終端整合
 ```lua
-<C-`>       -- VS Code 風格終端開關
+<C-`>       -- VS Code 風格終端開關（在 tmux 外使用）
+<leader>tt  -- tmux 相容終端切換（space tt，所有環境皆可用）
 <leader>cd  -- 同步 Neovim 工作目錄與終端目錄（CdVimDirHere）
 ```
 
@@ -234,6 +235,7 @@ end
 2. **Markdown 預覽失效**：確認 Node.js 路徑配置
 3. **中文顯示異常**：檢查 `ambiwidth` 設定
 4. **終端導航失效**：確認是否在終端模式中使用正確快捷鍵
+5. **tmux 中 Ctrl+` 無法使用**：改用 `<leader>tt` (space tt) 終端切換
 
 ### 調試技巧
 - 使用 `:checkhealth` 檢查插件狀態

--- a/init.lua
+++ b/init.lua
@@ -149,8 +149,8 @@ else
     )
 
 -- 模擬 VS Code 的 Ctrl + ` 開啟終端功能 do
--- vim.keymap.set({'n', 'i'}, '<C-`>', function()
-vim.keymap.set({'n', 'i', 't'}, '<C-`>', function()
+-- 提取終端切換邏輯為共用函數
+local function toggle_terminal()
   -- 如果在終端模式，先退出到普通模式
   if vim.api.nvim_get_mode().mode == 't' then
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-\\><C-n>', true, true, true), 'n', false)
@@ -176,27 +176,23 @@ vim.keymap.set({'n', 'i', 't'}, '<C-`>', function()
     end
   end
   
--- 如果找到顯示終端的視窗，關閉它
-  -- if term_win ~= nil then
-  --   vim.api.nvim_win_close(term_win, false)
-  --   return
-  -- end
-if term_win ~= nil then
-  -- 檢查當前視窗是否就是終端視窗
-  local current_win = vim.api.nvim_get_current_win()
-  if current_win == term_win then
-    -- 如果當前已在終端視窗，則關閉它
-    vim.api.nvim_win_close(term_win, false)
-  else
-    -- 如果終端視窗已開啟但不是當前視窗，則切換焦點到終端視窗
-    vim.api.nvim_set_current_win(term_win)
-    -- 如果是從非終端模式切換過來，自動進入插入模式
-    if vim.api.nvim_get_mode().mode ~= 't' then
-      vim.cmd('startinsert')
+  -- 如果找到顯示終端的視窗，處理切換邏輯
+  if term_win ~= nil then
+    -- 檢查當前視窗是否就是終端視窗
+    local current_win = vim.api.nvim_get_current_win()
+    if current_win == term_win then
+      -- 如果當前已在終端視窗，則關閉它
+      vim.api.nvim_win_close(term_win, false)
+    else
+      -- 如果終端視窗已開啟但不是當前視窗，則切換焦點到終端視窗
+      vim.api.nvim_set_current_win(term_win)
+      -- 如果是從非終端模式切換過來，自動進入插入模式
+      if vim.api.nvim_get_mode().mode ~= 't' then
+        vim.cmd('startinsert')
+      end
     end
+    return
   end
-  return
-end
   
   -- 如果沒有顯示終端的視窗，則開啟/創建終端
   if #term_buffers > 0 then
@@ -214,38 +210,13 @@ end
     vim.cmd('terminal')
     vim.cmd('startinsert')
   end
-  -- if #term_buffers > 0 then
-  --   -- 如果已有終端，切換到第一個終端緩衝區
-  --   local windows = vim.api.nvim_list_wins()
-  --   local term_found = false
-  --
-  --   -- 先檢查是否有顯示終端的視窗
-  --   for _, win in ipairs(windows) do
-  --     local buf = vim.api.nvim_win_get_buf(win)
-  --     if vim.bo[buf].buftype == 'terminal' then
-  --       vim.api.nvim_set_current_win(win)
-  --       term_found = true
-  --       break
-  --     end
-  --   end
-  --
-  --   -- 如果沒有顯示終端的視窗，開啟一個新的底部終端視窗
-  --   if not term_found then
-  --     vim.cmd('split')
-  --     vim.cmd('wincmd J')  -- 將視窗移到最底部
-  --     vim.cmd('resize 23%')
-  --     vim.cmd('buffer ' .. term_buffers[1])
-  --     vim.cmd('startinsert')
-  --   end
-  -- else
-  --   -- 如果沒有終端，創建一個新的底部終端
-  --   vim.cmd('split')
-  --   vim.cmd('wincmd J')  -- 將視窗移到最底部
-  --   vim.cmd('resize 23%')
-  --   vim.cmd('terminal')
-  --   vim.cmd('startinsert')
-  -- end
-end, { desc = 'VS Code 風格終端開關 (Ctrl+`)' , noremap = true})
+end
+
+-- 原有的 Ctrl+` 快捷鍵映射（保持向後相容）
+vim.keymap.set({'n', 'i', 't'}, '<C-`>', toggle_terminal, { desc = 'VS Code 風格終端開關 (Ctrl+`)' , noremap = true})
+
+-- 新增 <leader>tt 作為 tmux 相容的終端切換快捷鍵
+vim.keymap.set({'n', 'i', 't'}, '<leader>tt', toggle_terminal, { desc = 'tmux 相容終端切換 (space tt)' , noremap = true})
     -- 模擬 VS Code 的 Ctrl + ` 開啟終端功能 end
 
 


### PR DESCRIPTION
## 解決問題
解決 Issue #9：tmux 環境中 Ctrl+` 無法使用的問題

## 技術原因
- tmux 會將 Ctrl+` 轉換為 ASCII NUL (0)，與 Ctrl+Space/Ctrl+2 產生衝突
- 導致 Neovim 無法正確識別 Ctrl+` 按鍵組合

## 解決方案
1. **保持向後相容**：保留原有 `<C-`>` 快捷鍵供非 tmux 環境使用
2. **新增替代方案**：新增 `<leader>tt` (space tt) 作為所有環境皆可用的終端切換快捷鍵
3. **程式碼重構**：提取 `toggle_terminal()` 共用函數，避免程式碼重複

## 主要變更
- 提取終端切換邏輯為 `toggle_terminal()` 函數
- 新增 `<leader>tt` 快捷鍵映射，支援 normal/insert/terminal 三種模式
- 更新 CLAUDE.md 文檔，說明兩種快捷鍵的適用場景
- 新增故障排除章節，協助用戶選擇適合的快捷鍵

## 測試建議
在 tmux 環境中測試：
1. `Ctrl+`： 可能無法正常工作（預期行為）
2. `space` + `t` + `t`：應該可以正常切換終端

Fixes #9