### PR TITLE
feat: 增強 Git diff 顏色對比解決視覺效果問題 (Issue #18)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -436,6 +436,12 @@ require("lazy").setup({
 		    -- 設定註解的顏色（無斜體但顏色更鮮明）
 		    vim.api.nvim_set_hl(0, "Comment", { fg = "#7a88cf", italic = false })
 		    vim.api.nvim_set_hl(0, "gitcommitComment", { fg = "#7a88cf", italic = false })
+		    
+		    -- 增強 Git diff 顏色對比 (Issue #18)
+		    vim.api.nvim_set_hl(0, "DiffAdd", { bg = "#1a4a1a", fg = "#7dcfff" })
+		    vim.api.nvim_set_hl(0, "DiffDelete", { bg = "#4a1a1a", fg = "#f7768e" })
+		    vim.api.nvim_set_hl(0, "DiffChange", { bg = "#1a1a4a", fg = "#e0af68" })
+		    vim.api.nvim_set_hl(0, "DiffText", { bg = "#4a4a1a", fg = "#bb9af7" })
 		  end
 		})
 	  end,
@@ -1225,6 +1231,9 @@ end
 
 
 
+
+
+ 
 
 
 


### PR DESCRIPTION
## 解決問題
修復 Issue #18：Git diff 顏色對比不夠明顯的視覺效果問題。

## 實作內容

### 🎨 方案 A：增強現有顏色對比
實作分析報告中建議的方案 A，在現有 ColorScheme autocmd 中加入 diff 顏色覆寫：

```lua
-- 增強 Git diff 顏色對比 (Issue #18)
vim.api.nvim_set_hl(0, "DiffAdd", { bg = "#1a4a1a", fg = "#7dcfff" })
vim.api.nvim_set_hl(0, "DiffDelete", { bg = "#4a1a1a", fg = "#f7768e" })
vim.api.nvim_set_hl(0, "DiffChange", { bg = "#1a1a4a", fg = "#e0af68" })
vim.api.nvim_set_hl(0, "DiffText", { bg = "#4a4a1a", fg = "#bb9af7" })
```

### 📊 顏色設計邏輯
- **DiffAdd**：深綠背景 + 亮青前景 - 清楚標示新增內容
- **DiffDelete**：深紅背景 + 粉紅前景 - 明顯標示刪除內容  
- **DiffChange**：深藍背景 + 黃色前景 - 突出變更內容
- **DiffText**：深紫背景 + 紫色前景 - 精準標示變更文字

## 技術細節

### 🔧 實作位置
- 文件：`init.lua` 第 440-444 行
- 位置：現有 ColorScheme autocmd 中，與 git commit 註解設定一起管理
- 觸發：colorscheme 載入時自動應用

### 🎯 解決的根本問題
Tokyo Night 主題原生 diff 顏色配置透明度過低：
```lua
colors.diff = {
  add = Util.blend_bg(colors.green2, 0.15),    -- 僅 15% 透明度
  delete = Util.blend_bg(colors.red1, 0.15),
  change = Util.blend_bg(colors.blue7, 0.15),
}
```

## 測試範圍

### ✅ 受益功能
- `<leader>gd` - 工作目錄 vs 暫存區 diff
- `<leader>gD` - 工作目錄 vs HEAD diff
- `<leader>gS` - 暫存區 vs HEAD diff
- 所有 vim-fugitive 相關的 diff 視窗

### 🔍 預期改善效果
- ✅ 差異內容一眼可辨識
- ✅ 前景背景雙重對比，視覺層次分明
- ✅ 大幅提升 code review 效率
- ✅ 保持與 Tokyo Night 主題的整體協調性

## 相容性

- **主題相容**：僅覆寫 diff 相關顏色，不影響其他元素
- **功能相容**：與現有 Git 工作流程完全相容
- **配置整合**：與現有 ColorScheme autocmd 整合，統一管理

## 後續計畫

此 PR 解決了 Issue #18 的視覺效果問題。Issue #20 (vim-fugitive diff 導航功能) 將在後續 PR 中處理。

Fixes #18