### PR TITLE
feat: 嘗試修復 Visual Line 刪除線 surround 問題 (Issue #15)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -386,14 +386,7 @@ require("lazy").setup({
           },
           -- 刪除線 (Strikethrough)
              ["S"] = {
-            add = function()
-              -- 檢查是否在 Visual Line 模式 (V)
-              if vim.fn.mode() == "V" then
-                return { "~~", "~~\n" }  -- 在行尾前添加結束標記
-              else
-                return { "~~", "~~" }  -- 正常情況
-              end
-            end,
+            add = { "~~", "~~" },
             find = function()
               return require("nvim-surround.config").get_selection({ pattern = "~~.-~~" })
             end,

--- a/init.lua
+++ b/init.lua
@@ -385,6 +385,8 @@ require("lazy").setup({
             end,
           },
           -- 刪除線 (Strikethrough)
+          -- 注意：受 nvim-surround 架構限制，單行 Visual Line 仍會強制上下行加入
+          -- 詳見 Issue #22，此為嘗試性實作
              ["S"] = {
             add = function()
               local mode = vim.fn.visualmode()
@@ -395,14 +397,14 @@ require("lazy").setup({
                 local last_line = vim.fn.line("'>")
                 
                 if first_line == last_line then
-                  -- 單行 Visual Line：左右加入
+                  -- 單行 Visual Line：期望左右加入（目前受限制無效）
                   return { "~~", "~~" }
                 else
-                  -- 多行 Visual Line：回歸原生跨行邏輯
+                  -- 多行 Visual Line：回歸原生跨行邏輯（有效）
                   return nil
                 end
               else
-                -- 字符模式：正常處理
+                -- 字符模式：正常處理（有效）
                 return { "~~", "~~" }
               end
             end,

--- a/init.lua
+++ b/init.lua
@@ -386,7 +386,26 @@ require("lazy").setup({
           },
           -- 刪除線 (Strikethrough)
              ["S"] = {
-            add = { "~~", "~~" },
+            add = function()
+              local mode = vim.fn.visualmode()
+              
+              if mode == "V" then
+                -- Visual Line 模式：檢查是否為單行
+                local first_line = vim.fn.line("'<")
+                local last_line = vim.fn.line("'>")
+                
+                if first_line == last_line then
+                  -- 單行 Visual Line：左右加入
+                  return { "~~", "~~" }
+                else
+                  -- 多行 Visual Line：回歸原生跨行邏輯
+                  return nil
+                end
+              else
+                -- 字符模式：正常處理
+                return { "~~", "~~" }
+              end
+            end,
             find = function()
               return require("nvim-surround.config").get_selection({ pattern = "~~.-~~" })
             end,


### PR DESCRIPTION
## 解決問題
處理 Issue #15：`S-$` 以後如果 surround 應該不是上下行 surround

## 實作內容

### 🔧 智能 Visual Line 邏輯
```lua
["S"] = {
  add = function()
    local mode = vim.fn.visualmode()
    
    if mode == "V" then
      local first_line = vim.fn.line("'<")
      local last_line = vim.fn.line("'>")
      
      if first_line == last_line then
        -- 單行 Visual Line：期望左右加入
        return { "~~", "~~" }
      else
        -- 多行 Visual Line：回歸原生跨行邏輯
        return nil
      end
    else
      -- 字符模式：正常處理
      return { "~~", "~~" }
    end
  end,
}
```

## ⚠️ 已知限制

經測試發現 nvim-surround 架構限制：
- Visual Line 模式會被強制設為 `line_mode = true`
- 自動在 delimiters 中添加換行符
- 無法通過 `add` 函數自定義來解決

詳細分析已記錄到 Issue #22。

## 測試結果

- ✅ **初步修復移除錯誤邏輯**：移除原本錯誤的 `{ "~~", "~~\n" }` 
- ❌ **單行 Visual Line 仍加在上下**：受 nvim-surround 架構限制
- ✅ **字符模式正常**：`S-e` 等操作不受影響

Related to #15, #22