### PR TITLE
feat: 新增 TypeScript LSP 支援 (使用 ts_ls 替代已棄用的 tsserver)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -543,10 +543,11 @@ require("lazy").setup({
       -- 設定 mason
       require("mason").setup()
       require("mason-lspconfig").setup({
-        ensure_installed = { 
+        ensure_installed = {
           "jdtls" ,  --java lsp
-          "marksman" --markdown lsp 
-        }, 
+          "marksman", --markdown lsp
+          "ts_ls"    --typescript lsp
+        },
       })
 
       -- 設定 LSP 按鍵映射
@@ -579,6 +580,11 @@ require("lazy").setup({
         on_attach = on_attach,  -- 使用您現有的 on_attach 函數
       })
 
+      -- 配置 ts_ls
+      require('lspconfig').ts_ls.setup({
+        on_attach = on_attach,
+      })
+
       -- 配置 jdtls
       require('lspconfig').jdtls.setup({
         on_attach = on_attach,
@@ -597,6 +603,8 @@ require("lazy").setup({
           "-data", jdtls_workspace_dir .. vim.fn.getcwd(),
         },
       })
+
+      
 
       -- 配置錯誤顯示
       vim.diagnostic.config({


### PR DESCRIPTION
## 📋 Summary

解決 Issue #29：為 Neovim 配置新增 TypeScript 語言伺服器支援

## 🔧 Changes

### 修正內容
- ✅ 在 `mason-lspconfig` 的 `ensure_installed` 清單中加入 `ts_ls`
- ✅ 新增 `ts_ls.setup()` 配置到 LSP 設定區塊
- ✅ 使用 `ts_ls` 替代已棄用的 `tsserver` 命名

### 技術細節
- **原因**：`tsserver` 已被 lspconfig 官方棄用，重新命名為 `ts_ls`
- **位置**：`init.lua` 第 549 行和第 583-586 行
- **配置**：使用現有的 `on_attach` 函數確保快捷鍵一致性

## ✨ Expected Features

設定完成後將獲得：
- TypeScript/JavaScript 語法檢查和錯誤提示
- 自動補全和智能提示功能
- 函數定義跳轉 (`gd`)
- Hover 資訊顯示 (`K`)
- LSP 診斷導航 (`[d`, `]d`)
- 程式碼格式化支援

## 📝 Installation Steps

使用者需要手動執行：
1. 重啟 Neovim
2. 執行 `:Mason`
3. 搜尋並安裝 `typescript-language-server`
4. 執行 `:LspInfo` 確認 `ts_ls` 正常運作

## 🔗 Related

- Closes #29
- 參考：[lspconfig tsserver 棄用通知](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tsserver)

## 📸 Testing

```bash
# 創建測試檔案
nvim test.ts

# 輸入測試程式碼
const message: string = "Hello TypeScript!"

# 檢查 LSP 狀態
:LspInfo
# 應顯示 ts_ls active
```