### PR TITLE
feat: 新增顯示器切換色彩修復系統

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1287,6 +1287,58 @@ do
   vim.keymap.set('n', '<leader>lx', ':LiveServerStop<CR>', { desc = '停止 Live Server', silent = true })
 end
 
+-- ================================================================
+-- 顯示器切換色彩修復系統 (Issue #36)
+-- ================================================================
+
+-- Level 0: 色彩診斷工具
+vim.api.nvim_create_user_command('ColorDebug', function()
+  print("=== 色彩診斷報告 ===")
+  print("TERM: " .. (vim.env.TERM or "未設定"))
+  print("COLORTERM: " .. (vim.env.COLORTERM or "未設定"))
+  print("termguicolors: " .. tostring(vim.opt.termguicolors:get()))
+  print("色彩支援: " .. (vim.fn.has('termguicolors') == 1 and "是" or "否"))
+  print("tput colors: " .. (vim.fn.system('tput colors'):gsub('\n', '') or "無法檢測"))
+  print("當前主題: " .. (vim.g.colors_name or "未設定"))
+end, { desc = "診斷色彩環境狀態" })
+
+-- Level 1: 強制色彩修復
+local function force_color_fix()
+  -- 步驟1: 強制重設終端環境變數
+  vim.env.TERM = "xterm-256color"
+  vim.env.COLORTERM = "truecolor"
+
+  -- 步驟2: 強制啟用 Neovim 色彩功能
+  vim.opt.termguicolors = true
+
+  -- 步驟3: 重新載入主題
+  pcall(function()
+    vim.cmd('colorscheme tokyonight-night')
+  end)
+
+  -- 步驟4: 強制刷新畫面
+  vim.cmd('redraw!')
+
+  -- 步驟5: 顯示修復狀態
+  print("🎨 色彩已強制修復！")
+end
+
+-- 自動觸發：當 Neovim 獲得焦點或啟動時
+vim.api.nvim_create_autocmd({ "VimEnter", "FocusGained" }, {
+  group = vim.api.nvim_create_augroup("ColorFix", { clear = true }),
+  callback = function()
+    -- 檢查是否需要修復（避免不必要的操作）
+    if vim.fn.has('termguicolors') == 0 or vim.env.TERM == "vt100" then
+      force_color_fix()
+    end
+  end,
+})
+
+-- 手動觸發：命令
+vim.api.nvim_create_user_command('ColorFix', force_color_fix, {
+  desc = "強制修復色彩環境"
+})
+
 
 
 


### PR DESCRIPTION
## 🎯 功能概述

新增顯示器切換色彩修復系統，解決 macOS 顯示器熱插拔後 Neovim 色彩完全失效的問題。

## 🚨 問題背景

- **觸發情境**：外接顯示器切換、全螢幕切換、投影設備熱插拔
- **問題表現**：Neovim 完全失去色彩（連 16 色都沒有，變成純黑白）
- **根本原因**：macOS 重置終端環境，termguicolors 檢測失效

## 🔧 解決方案

### 新增功能

#### 1. 診斷工具
```vim
:ColorDebug
```
- 檢查 TERM、COLORTERM 環境變數
- 顯示 termguicolors 狀態和色彩支援
- 快速定位問題原因

#### 2. 修復工具  
```vim
:ColorFix
```
- 強制重設終端環境變數
- 重新啟用 termguicolors
- 重新載入 tokyonight 主題

#### 3. 自動檢測
- VimEnter 和 FocusGained 時自動檢測
- 智能判斷是否需要修復
- 避免不必要的操作

## 📋 使用方式

**正常情況**：完全感覺不到這個系統存在

**顯示器切換後色彩失效時**：
```vim
:ColorFix    # 一鍵修復
```

## ✅ 優點

- **無侵入性**：完全不影響現有配置和功能
- **應急工具**：只在需要時才發揮作用  
- **智能檢測**：自動判斷是否需要修復
- **簡單易用**：一個命令解決問題

## 🔗 解決的問題

- ✅ **Issue #36**：顯示器切換色彩失效問題
- 🎯 **提升使用體驗**：避免手動重啟 Neovim
- 🛡️ **預防機制**：自動檢測和修復

系統已就緒，等待實際問題發生時驗證效果。