### PR TITLE
feat: 新增 :CleanFB 清除零寬空格命令 (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ Comment/gitcommitComment = { fg = "#7a88cf", italic = false }
 ```
 :NewFile     -- 進階檔案創建（Telescope 整合）
 :CdVimDirHere -- 同步工作目錄
+:CleanFB     -- 清除零寬空格 (U+200B)，常見於 Facebook 複製貼上
 ```
 
 ### Markdown 工具

--- a/init.lua
+++ b/init.lua
@@ -817,6 +817,26 @@ vim.api.nvim_create_user_command('CdVimDirHere', function()
 end, {})
 
 
+-- 清除 Facebook 等平台複製貼上夾帶的零寬空格 (U+200B)
+vim.api.nvim_create_user_command('CleanFB', function()
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local count = 0
+  for i, line in ipairs(lines) do
+    local new_line, n = line:gsub('\u{200b}', '')
+    if n > 0 then
+      lines[i] = new_line
+      count = count + n
+    end
+  end
+  if count > 0 then
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+    vim.notify('已清除 ' .. count .. ' 個零寬空格')
+  else
+    vim.notify('沒有找到零寬空格')
+  end
+end, { desc = '清除零寬空格 (U+200B)' })
+
+
 -- 將所有 Markdown 相關設定整合到一個 autocmd 中
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "markdown",


### PR DESCRIPTION
Closes #56

## 變更

- 新增 `:CleanFB` user command,清除緩衝區內所有 U+200B 零寬空格
- `CLAUDE.md`「常用自訂命令」清單補上一筆

## 背景

從 Facebook 等社群平台複製文字後常夾帶 U+200B,肉眼看不到,但會破壞搜尋、grep、字串比對。

## 設計取捨

- **純 Lua API,不用 `:%s/.../...`**:不污染搜尋歷史、不動游標
- **只清 U+200B**:不清 U+200C/U+200D(在阿拉伯文/印地文/Emoji ZWJ 組合字有意義),U+FEFF 由 Hammerspoon 端負責
- **採 user command 而非 BufWritePre 自動清**:避免最小驚訝原則違反,markdown 可能有刻意保留特殊字元的場景

## 用法

```vim
:CleanFB
" 找到時 notify「已清除 N 個零寬空格」
" 沒找到時 notify「沒有找到零寬空格」
```

## 與 Hammerspoon 的關係

預期搭配 [hammerspoon-settings#1](https://github.com/Shiou-Ju/hammerspoon-settings/issues/1) 一起使用:
- Hammerspoon Cmd+Shift+V 在輸入端清(預防,跨 app 通用)
- nvim `:CleanFB` 處理已存在檔案(補救)

職責互補,不衝突。

## 驗證

```vim
:e /tmp/zws-test.md
:lua vim.api.nvim_put({'hello​world'}, 'l', false, false)
:CleanFB
" 預期:notify「已清除 1 個零寬空格」
:CleanFB
" 預期:notify「沒有找到零寬空格」
```