### PR TITLE
feat: Telescope 改用 flex 佈局自動適應視窗寬度

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -545,10 +545,12 @@ require("lazy").setup({
           },
         },
         sorting_strategy = "ascending",  -- 使結果從上往下排列，類似 VS Code
+        layout_strategy = "flex",        -- 依視窗寬度自動切換水平/垂直佈局
         layout_config = {
-          horizontal = {
-            prompt_position = "top",  -- 將提示放在頂部
-          },
+          prompt_position = "top",       -- 提示固定在頂部（兩種佈局都套用）
+          flex = { flip_columns = 120 }, -- 視窗寬度 < 120 欄時改為上下排
+          horizontal = { preview_width = 0.55 },
+          vertical = { preview_height = 0.5 },
         },
       },
       pickers = {


### PR DESCRIPTION
Closes #58
Closes #59

## 變更

- Telescope `defaults` 改用 `layout_strategy = "flex"`,依視窗寬度自動切換水平/垂直佈局
- `flip_columns = 120`:視窗寬度 < 120 欄時改為上下分割
- `prompt_position` 上移至 `layout_config` 頂層,讓兩種佈局共用
- 補上 `horizontal.preview_width = 0.55`、`vertical.preview_height = 0.5`

## 背景

窄(直立)終端視窗開 Telescope 時,預設 horizontal 佈局左右各半,導致左欄結果片段被截、右欄預覽擠出畫面(#58)。

## 相關:Nerd Font(#59)

同次處理了結果列前圖示顯示為「?」的問題:屬終端字型層級,**無 repo 變更**。已裝 `font-hack-nerd-font` 並設 iTerm2 字型為 Hack Nerd Font Mono,圖示恢復正常(詳見 #59 留言)。一併以此 PR 連結結案。

## 驗證

- `luac -p` 語法檢查通過
- 寬視窗:維持「結果左、預覽右」
- 窄視窗(< 120 欄):自動改「結果上、預覽下」,預覽完整不截斷
- 圖示:Nerd Font 套用後正確顯示彩色檔案圖示