### PR TITLE
feat: 新增 space space 快速回到上一個檔案

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -64,6 +64,8 @@ else
     vim.keymap.set('n', '<leader>j', '<C-w>j', { desc = '向下切換視窗' })
     vim.keymap.set('n', '<leader>k', '<C-w>k', { desc = '向上切換視窗' })
     vim.keymap.set('n', '<leader>l', '<C-w>l', { desc = '向右切換視窗' })
+    -- 快速回到上一個檔案：在當前與前一個編輯檔案間 toggle (Issue #63)
+    vim.keymap.set('n', '<leader><leader>', '<C-^>', { desc = '回到上一個檔案 (alternate file)' })
     -- 專門處理 terminal 的視窗
     -- vim.keymap.set('t', 'JKL', '<C-\\><C-n>', { desc = '使用 JKL 退出終端模式' })
 


### PR DESCRIPTION
## 變更內容

新增快捷鍵 `<leader><leader>`（連按兩下空白），綁定至 Neovim 內建 `<C-^>`，在當前與前一個編輯檔案間快速 toggle。

- 採 A 方案（兩檔來回 toggle）：A↔B，再按一次切回。
- 僅加在 non-vscode 分支（issue 針對 Neovim）。
- 與 `<leader>fr`（telescope oldfiles，列多個最近檔案）互補，不重複。

## 驗證

- headless 已確認映射存在：`rhs=<C-^>`、desc 正確；`luac -p` 語法通過。
- 互動確認：開檔案 A → 開檔案 B → `<leader><leader>` 回到 A，再按回到 B。

## 後續考量

「連按可往回穿越 3+ 個最近檔案」（MRU 堆疊 / 循環）非本次範圍，已記錄於 issue comment。

Closes #63