### PR TITLE
fix: fg 預覽窗命中行高亮改黃底黑字(取代偏淡預設)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -528,6 +528,8 @@ require("lazy").setup({
 
 		    -- 讓 Telescope 搜尋關鍵字更明顯：黃底黑字加粗 (Issue #62)
 		    vim.api.nvim_set_hl(0, "TelescopeMatching", { fg = "#1a1b26", bg = "#ffc777", bold = true })
+		    -- 預覽窗命中行整行高亮：黃底黑字加粗，取代偏淡的預設 Visual (Issue #74)
+		    vim.api.nvim_set_hl(0, "TelescopePreviewLine", { fg = "#1a1b26", bg = "#ffc777", bold = true })
 		  end
 		})
 		-- autocmd 註冊在 colorscheme 套用之後，啟動時不會自動觸發，故立即手動觸發一次

--- a/mockups/telescope-preview-highlight/README.md
+++ b/mockups/telescope-preview-highlight/README.md
@@ -1,0 +1,32 @@
+# TelescopePreviewLine 高亮樣式對照 (Issue #74)
+
+`<leader>fg` 預覽窗命中行用 `TelescopePreviewLine` 整行高亮,但目前沿用 Telescope 預設 `link = "Visual"`(tokyonight night ≈ `#283457`),對比太低、偏淡。本資料夾提供視覺對照,供挑選新樣式。
+
+## 用途
+純參考 mockup(HTML),不影響 Neovim 設定。
+
+## 如何看
+瀏覽器直接開 `index.html`:
+```
+open index.html        # macOS
+```
+或在 nvim 裡用既有 `:LiveServer` / Live Server 快捷鍵預覽。
+
+## 內容
+並排展示「目前樣式」與 4 種更新候選:
+- **A** 亮藍底 `#3d59a1`(同色系加亮)
+- **B** 黃色左側 accent bar + 微底 `#24304e`(需 extmark/sign 實作 bar)
+- **C** 黃底黑字整行 `#ffc777`(最醒目,呼應結果列表 `TelescopeMatching`)
+- **D** 中藍底 `#2e3c64` + 粗體亮字
+
+每格附對應的 `nvim_set_hl(...)` Lua 片段。
+
+## 選定後怎麼套
+把選定候選的片段加進 `init.lua` 的 `ColorScheme` autocmd,緊鄰既有的 `TelescopeMatching` 設定:
+```lua
+vim.api.nvim_set_hl(0, "TelescopePreviewLine", { bg = "<選定色>", bold = true })
+```
+之後在實機 `<leader>fg` 確認醒目度。
+
+## 色值來源(tokyonight night)
+底 `#1a1b26` / 前景 `#c0caf5` / Visual `#283457` / 黃 `#ffc777` / blue0 `#3d59a1`。

--- a/mockups/telescope-preview-highlight/index.html
+++ b/mockups/telescope-preview-highlight/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TelescopePreviewLine 高亮樣式對照 (Issue #74)</title>
+<style>
+  :root {
+    --bg: #1a1b26;          /* tokyonight night 編輯區底 */
+    --bg-dark: #16161e;     /* 外框/側邊 */
+    --fg: #c0caf5;          /* 前景 */
+    --comment: #565f89;     /* 註解/淡字 */
+    --linenr: #3b4261;      /* 行號 */
+    --linenr-cur: #ff9e64;  /* CursorLineNr 橘 */
+    --yellow: #ffc777;      /* TelescopeMatching 黃底 */
+    --blue: #7aa2f7;
+    --green: #9ece6a;
+    --cyan: #7dcfff;
+    --magenta: #bb9af7;
+    /* 預覽行候選 */
+    --visual: #283457;      /* 目前 (Visual) */
+    --blue0: #3d59a1;       /* A 亮藍 */
+    --b-bg: #24304e;        /* B 微底 */
+    --d-bg: #2e3c64;        /* D 中藍 */
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px;
+    background: #0c0e14;
+    color: var(--fg);
+    font-family: -apple-system, "PingFang TC", "Microsoft JhengHei", sans-serif;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: #8a91b8; font-size: 13px; margin-bottom: 24px; }
+  .sub code { color: var(--yellow); }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+    gap: 20px;
+  }
+  .card {
+    background: var(--bg-dark);
+    border: 1px solid #20222e;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .card.current { border-color: #f7768e55; }
+  .card-head {
+    padding: 10px 14px;
+    border-bottom: 1px solid #20222e;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .tag {
+    font-size: 11px; font-weight: 700;
+    padding: 2px 8px; border-radius: 10px;
+    background: #2a2e42; color: var(--blue);
+  }
+  .tag.now { background: #3a2230; color: #f7768e; }
+  .card-head .name { font-size: 14px; font-weight: 600; }
+  /* 模擬 Telescope 預覽窗 */
+  .preview {
+    background: var(--bg);
+    font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
+    font-size: 13px; line-height: 1.7;
+    padding: 8px 0;
+  }
+  .row { display: flex; padding: 0 12px; white-space: pre; }
+  .ln { color: var(--linenr); width: 34px; text-align: right; padding-right: 14px; user-select: none; flex: none; }
+  .txt { color: var(--fg); }
+  .txt .c { color: var(--comment); }
+  .txt .k { color: var(--magenta); }
+  .txt .s { color: var(--green); }
+  .txt .f { color: var(--blue); }
+  /* 命中字(列表/行內)黃底黑字 = TelescopeMatching */
+  .match { background: var(--yellow); color: var(--bg); border-radius: 2px; font-weight: 700; }
+
+  /* === 預覽命中行各候選 === */
+  .hit { } /* 基底 */
+  .now  .hit { background: var(--visual); }
+  .A    .hit { background: var(--blue0); }
+  .B    .hit { background: var(--b-bg); box-shadow: inset 3px 0 0 var(--yellow); }
+  .C    .hit { background: var(--yellow); }
+  .C    .hit .ln { color: #1a1b2699; }
+  .C    .hit .txt, .C .hit .txt * { color: var(--bg) !important; font-weight: 600; }
+  .D    .hit { background: var(--d-bg); }
+  .D    .hit .txt { color: #ffffff; font-weight: 700; }
+  .now .hit .ln, .A .hit .ln, .B .hit .ln, .D .hit .ln { color: var(--linenr-cur); }
+
+  .lua {
+    font-family: "SF Mono", Menlo, monospace; font-size: 11.5px;
+    background: #11131c; color: #9aa5ce;
+    padding: 10px 14px; border-top: 1px solid #20222e;
+    white-space: pre-wrap; word-break: break-all;
+  }
+  .lua .hl { color: var(--yellow); }
+  .legend { margin-top: 28px; font-size: 12.5px; color: #8a91b8; }
+  .legend b { color: var(--fg); }
+  .swatch { display: inline-block; width: 11px; height: 11px; border-radius: 2px; vertical-align: middle; margin: 0 4px; border: 1px solid #ffffff22; }
+</style>
+</head>
+<body>
+  <h1>fg 預覽窗命中行高亮樣式對照</h1>
+  <div class="sub">Issue #74 · tokyonight night · 底色 <code>#1a1b26</code> · 命中字黃底 = <code>TelescopeMatching</code>(#62 已優化)· 本對照針對<b style="color:#fff">預覽窗整行高亮 <code>TelescopePreviewLine</code></b></div>
+
+  <div class="grid">
+
+    <!-- 目前 -->
+    <div class="card current now">
+      <div class="card-head"><span class="tag now">目前</span><span class="name">預設 Visual（偏淡）</span></div>
+      <div class="preview">
+        <div class="row"><span class="ln">619</span><span class="txt"><span class="c"># 筆記標題</span></span></div>
+        <div class="row"><span class="ln">620</span><span class="txt">前一行內容，作為上下文。</span></div>
+        <div class="row hit"><span class="ln">621</span><span class="txt">這一行包含 <span class="match">關鍵字</span> 命中，整行被高亮。</span></div>
+        <div class="row"><span class="ln">622</span><span class="txt">後一行內容，作為上下文。</span></div>
+        <div class="row"><span class="ln">623</span><span class="txt"><span class="k">const</span> x = <span class="s">"範例"</span></span></div>
+      </div>
+      <div class="lua">-- 現狀：未自訂，link = "Visual" ≈ <span class="hl">#283457</span>（對比過低）</div>
+    </div>
+
+    <!-- A 亮藍底 -->
+    <div class="card A">
+      <div class="card-head"><span class="tag">候選 A</span><span class="name">亮藍底（同色系加亮）</span></div>
+      <div class="preview">
+        <div class="row"><span class="ln">619</span><span class="txt"><span class="c"># 筆記標題</span></span></div>
+        <div class="row"><span class="ln">620</span><span class="txt">前一行內容，作為上下文。</span></div>
+        <div class="row hit"><span class="ln">621</span><span class="txt">這一行包含 <span class="match">關鍵字</span> 命中，整行被高亮。</span></div>
+        <div class="row"><span class="ln">622</span><span class="txt">後一行內容，作為上下文。</span></div>
+        <div class="row"><span class="ln">623</span><span class="txt"><span class="k">const</span> x = <span class="s">"範例"</span></span></div>
+      </div>
+      <div class="lua">nvim_set_hl(0, "TelescopePreviewLine", { bg = "<span class="hl">#3d59a1</span>", bold = true })</div>
+    </div>
+
+    <!-- B 黃 accent bar -->
+    <div class="card B">
+      <div class="card-head"><span class="tag">候選 B</span><span class="name">黃色左側 accent bar + 微底</span></div>
+      <div class="preview">
+        <div class="row"><span class="ln">619</span><span class="txt"><span class="c"># 筆記標題</span></span></div>
+        <div class="row"><span class="ln">620</span><span class="txt">前一行內容，作為上下文。</span></div>
+        <div class="row hit"><span class="ln">621</span><span class="txt">這一行包含 <span class="match">關鍵字</span> 命中，整行被高亮。</span></div>
+        <div class="row"><span class="ln">622</span><span class="txt">後一行內容，作為上下文。</span></div>
+        <div class="row"><span class="ln">623</span><span class="txt"><span class="k">const</span> x = <span class="s">"範例"</span></span></div>
+      </div>
+      <div class="lua">-- 需 sign/extmark 實作左側 bar；近似：
+nvim_set_hl(0, "TelescopePreviewLine", { bg = "<span class="hl">#24304e</span>" })</div>
+    </div>
+
+    <!-- C 黃底黑字 -->
+    <div class="card C">
+      <div class="card-head"><span class="tag">候選 C</span><span class="name">黃底黑字整行（最醒目，呼應列表）</span></div>
+      <div class="preview">
+        <div class="row"><span class="ln">619</span><span class="txt"><span class="c"># 筆記標題</span></span></div>
+        <div class="row"><span class="ln">620</span><span class="txt">前一行內容，作為上下文。</span></div>
+        <div class="row hit"><span class="ln">621</span><span class="txt">這一行包含 關鍵字 命中，整行被高亮。</span></div>
+        <div class="row"><span class="ln">622</span><span class="txt">後一行內容，作為上下文。</span></div>
+        <div class="row"><span class="ln">623</span><span class="txt"><span class="k">const</span> x = <span class="s">"範例"</span></span></div>
+      </div>
+      <div class="lua">nvim_set_hl(0, "TelescopePreviewLine", { bg = "<span class="hl">#ffc777</span>", fg = "#1a1b26", bold = true })</div>
+    </div>
+
+    <!-- D 中藍底粗亮字 -->
+    <div class="card D">
+      <div class="card-head"><span class="tag">候選 D</span><span class="name">中藍底 + 粗體亮字</span></div>
+      <div class="preview">
+        <div class="row"><span class="ln">619</span><span class="txt"><span class="c"># 筆記標題</span></span></div>
+        <div class="row"><span class="ln">620</span><span class="txt">前一行內容，作為上下文。</span></div>
+        <div class="row hit"><span class="ln">621</span><span class="txt">這一行包含 <span class="match">關鍵字</span> 命中，整行被高亮。</span></div>
+        <div class="row"><span class="ln">622</span><span class="txt">後一行內容，作為上下文。</span></div>
+        <div class="row"><span class="ln">623</span><span class="txt"><span class="k">const</span> x = <span class="s">"範例"</span></span></div>
+      </div>
+      <div class="lua">nvim_set_hl(0, "TelescopePreviewLine", { bg = "<span class="hl">#2e3c64</span>", fg = "#c0caf5", bold = true })</div>
+    </div>
+
+  </div>
+
+  <div class="legend">
+    <p><b>說明</b>：黃底黑字的「關鍵字」是結果列表既有的 <code>TelescopeMatching</code>（#62 已優化，本對照不變）。各卡片差異在<b>整行底色</b>（<code>TelescopePreviewLine</code>）。</p>
+    <p>色票：
+      目前 <span class="swatch" style="background:#283457"></span>#283457 ·
+      A <span class="swatch" style="background:#3d59a1"></span>#3d59a1 ·
+      B <span class="swatch" style="background:#24304e"></span>#24304e+<span class="swatch" style="background:#ffc777"></span>bar ·
+      C <span class="swatch" style="background:#ffc777"></span>#ffc777 ·
+      D <span class="swatch" style="background:#2e3c64"></span>#2e3c64
+    </p>
+    <p><b>選定後</b>：把對應 <code>nvim_set_hl(...)</code> 加進 <code>init.lua</code> 的 ColorScheme autocmd（緊鄰 <code>TelescopeMatching</code> 那行）。候選 B 的左側 bar 需用 extmark/sign 額外實作，單純底色版見片段。</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 變更

### fix: 預覽窗命中行高亮 (#74)
- `TelescopePreviewLine` 原沿用 Telescope 預設 `link = "Visual"`(tokyonight night ≈ `#283457`),偏淡幾乎看不見。
- 改為黃底黑字加粗 `{ bg = "#ffc777", fg = "#1a1b26", bold = true }`,與結果列表 `TelescopeMatching` 同調,命中行一眼可辨。
- 加在既有 ColorScheme autocmd,緊鄰 #62 的 `TelescopeMatching` 設定。

### docs: 樣式對照 mockup
- `mockups/telescope-preview-highlight/`:HTML 並排「目前 vs 4 候選(A 亮藍 / B accent bar / C 黃底 / D 中藍粗字)」,記錄選定 C 的設計依據。

## 已知取捨
命中行整行變黃底後,行內命中詞會與整行同色融合(看得到行、看不到詞)。可接受;日後若要兼顧詞的分辨可改 A/D 藍底系。

## 驗證
- headless nvim 確認 `TelescopePreviewLine` = `bg=#ffc777 fg=#1a1b26 bold=true`
- HTML 截圖目視確認 C 最醒目

Closes #74