### PR TITLE
feat: 導入 vim-tmux-navigator 無縫切換 vim/tmux (#76)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -387,6 +387,10 @@ vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter", "WinEnter"}, {
 
 -- 載入插件
 require("lazy").setup({
+    -- vim-tmux-navigator：Ctrl+hjkl 在 vim split 與 tmux pane 間無縫切換 (Shiou-Ju/nvim#76)
+    -- 接管 <C-h/j/k/l>，到 split 邊界自動跳回 tmux pane（對接 .tmux.conf 的 is_vim 區塊）
+    { "christoomey/vim-tmux-navigator", lazy = false },
+
     -- nvim-surround 插件
       -- 添加環繞 (Add surroundings)：
         -- ysiw B - 將游標所在單詞加粗

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -13,5 +13,6 @@
   "telescope.nvim": { "branch": "master", "commit": "a4ed82509cecc56df1c7138920a1aeaf246c0ac5" },
   "tokyonight.nvim": { "branch": "main", "commit": "057ef5d260c1931f1dffd0f052c685dcd14100a3" },
   "vim-fugitive": { "branch": "master", "commit": "61b51c09b7c9ce04e821f6cf76ea4f6f903e3cf4" },
-  "vim-markdown": { "branch": "master", "commit": "8f6cb3a6ca4e3b6bcda0730145a0b700f3481b51" }
+  "vim-markdown": { "branch": "master", "commit": "8f6cb3a6ca4e3b6bcda0730145a0b700f3481b51" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432" }
 }


### PR DESCRIPTION
## 背景
個人 dotfiles 的 `.tmux.conf` 已有無 prefix `Ctrl+hjkl` + `is_vim` 偵測，但 nvim 端缺對接 → 在 vim 內切不動 pane。

## 變更
- lazy.nvim 加入 `{ "christoomey/vim-tmux-navigator", lazy = false }`，接管 `<C-h/j/k/l>`，到 split 邊界自動跳回 tmux pane。
- `lazy-lock.json` 釘選 `e41c431`；**未連帶升級其他插件**（避免在 nvim 0.10.x 上拉到需 0.11 的 telescope/lspconfig）。

## 驗證
`<C-h/j/k/l>` 已映射至 `TmuxNavigate*`；啟動無 0.11 相容錯誤。實機 vim↔tmux 無縫切換手測待補。

## 注意
`Ctrl+h`=`^H`(backspace) 部分終端需修正（見 #76 留言）。lock 管理強化另開 #77。

Closes #76
