### PR TITLE
fix: 標記 lspconfig deprecated API 待遷移

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -681,6 +681,9 @@ require("lazy").setup({
       end
 
       -- 配置 marksman
+      --- @diagnostic disable-next-line: deprecated
+      -- FIXME:
+      -- issue #81
       require('lspconfig').marksman.setup({
         on_attach = on_attach,  -- 使用您現有的 on_attach 函數
       })


### PR DESCRIPTION
加入 FIXME 標記提醒遷移至 vim.lsp.config 新 API。