### PR TITLE
feat: 導入 nvim-unception 杜絕 :terminal 內巢狀 nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -407,6 +407,17 @@ require("lazy").setup({
       end,
     },
 
+    -- nvim-unception：杜絕 :terminal 內巢狀 nvim/vim，開檔導回宿主 nvim (Shiou-Ju/nvim#92)
+    -- 需早載入以在啟動時註冊 RPC server，故 lazy = false
+    {
+      "samjwill/nvim-unception",
+      lazy = false,
+      init = function()
+        -- 開檔導回父 nvim；git commit 等 $EDITOR 阻塞由 terminal-config 的 core.editor 處理
+        -- 可選：vim.g.unception_open_buffer_in_new_tab = true
+      end,
+    },
+
     -- nvim-surround 插件
       -- 添加環繞 (Add surroundings)：
         -- ysiw B - 將游標所在單詞加粗

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -8,6 +8,7 @@
   "nvim-lint": { "branch": "master", "commit": "9dfb77ef6c5092a19502883c02dc5a02ec648729" },
   "nvim-lspconfig": { "branch": "master", "commit": "37cc31c64d657feff6f752a1bf15f584d4734eca" },
   "nvim-surround": { "branch": "main", "commit": "0e62500b98f4513feaaf7425c135472457ea5b7d" },
+  "nvim-unception": { "branch": "main", "commit": "f14eeb22238d2c2bdafe9a2e5e1f4bd200d0e450" },
   "nvim-web-devicons": { "branch": "master", "commit": "50b5b06bff13a9b4eab946de7c7033649a6618a1" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
   "telescope.nvim": { "branch": "master", "commit": "a4ed82509cecc56df1c7138920a1aeaf246c0ac5" },


### PR DESCRIPTION
## 變更

新增 `samjwill/nvim-unception`（`lazy = false` 早載入），杜絕在 `:terminal` 內再開 `nvim` / `vim` / 檔案時巢狀出第二個全螢幕 TUI 造成的 libvterm 渲染問題。開檔請求導回宿主（父）nvim、focus 跟過去。

- `init.lua`：於 vim-tmux-navigator 後新增 plugin spec，`init` 內留設定註解（可選 `unception_open_buffer_in_new_tab`）。
- `lazy-lock.json`：僅新增 nvim-unception（pin `f14eeb2`），既有 pin 零變動（符合最小變動守則）。

## 驗證

- `Lazy! install` 只裝此插件；`git diff lazy-lock.json` 僅 +1 行，`nvim-lspconfig` 仍 `37cc31c`。
- `nvim --headless +qa` 乾淨啟動、無錯，插件已註冊於 lazy config。
- 待手動實測：進 vt → `:terminal` 內 `nvim file` / `vim file` 應開在父 nvim、focus 跟過去、不巢狀；git commit（`$EDITOR`）阻塞需搭配 terminal-config 的 `core.editor` 設定。

## 相關

- Closes #92
- Shiou-Ju/terminal-config#123（vt 內 v/vim 壞掉的根因與決策）
